### PR TITLE
feat: removed custom alias and use git plugin

### DIFF
--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -14,23 +14,6 @@ alias tree="find . -print | sed -e 's;[^/]*/;|____;g;s;____|; |;g'"
 alias sshkeys="tail +1 ~/.ssh/*.pub"
 
 # git
-alias gc='git clone'
-alias gp='git pull'
-alias gpu='git push'
-alias gll='git log --pretty=format:"%C(yellow)%h%Cred%d %Creset%s%Cblue [%cn]" --decorate'
-alias gl='git log --pretty=format:"%C(yellow)%h\\ %ad%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate --date=short'
-alias gs='git status -sb'
-alias gf='git fetch'
-alias gd='git diff'
-alias gm='git commit -m'
-alias gma='git commit -am'
-alias gb='git branch'
-alias gco='git checkout'
-alias gfo='git fetch origin'
-alias gra='git remote add'
-alias grr='git remote rm'
-alias gbr='git branch -r'
-alias gba='git branch -a'
 alias pubkey='pbcopy < ~/.ssh/id_rsa.pub'
 
 # iterate through all git repos and show the url

--- a/fish/fish_plugins
+++ b/fish/fish_plugins
@@ -3,3 +3,4 @@ paysonwallach/fish-you-should-use
 PatrickF1/fzf.fish
 jethrokuan/z
 jorgebucaran/nvm.fish
+jhillyerd/plugin-git


### PR DESCRIPTION
Removes custom git alias' for [fish plugin-git](https://github.com/jhillyerd/plugin-git) since it is very similar and has documentation all in the README for support.